### PR TITLE
Remove a race condition when reviewing daily mode's progress

### DIFF
--- a/app.js
+++ b/app.js
@@ -425,8 +425,7 @@ async function updateDaily() {
                 })
                 const guess = await result.json();
                 console.log(guess);
-                makeGuess(guess);
-                await timer(100);
+                await makeGuess(guess);
             }
             else break;
         }


### PR DESCRIPTION
Firstly, love the app!

The problem this is solving is that when you reload your daily guesses, it will nondeterministically display the guesses in the wrong order, especially nearer the end of your guess list.

I believe the HTTP call in the makeGuess function takes sufficient time that the 100ms wait is sometimes insufficient in ensuring the guesses return in the proper order, especially when the cache is clear and therefore the requests can take 300-400ms. By forcing the makeGuess call to be blocking you can ensure that you will not let later guesses "jump the queue".